### PR TITLE
fix(v2-support): update samples to use web core 2.x, ui-kit 2.x and video-background-transformer 2.x

### DIFF
--- a/samples/background-transformer-ui/README.md
+++ b/samples/background-transformer-ui/README.md
@@ -10,7 +10,7 @@ package.
 You can set:
 
 1. A background blur
-2. A backgriund image
+2. A background image
 
 <!-- With blur:
 

--- a/samples/background-transformer-ui/index.html
+++ b/samples/background-transformer-ui/index.html
@@ -18,11 +18,11 @@
       defineCustomElements();
     </script>
 
-    <!-- Import Web Core via CDN too -->
-    <script src="https://cdn.dyte.in/core/dyte.js"></script>
+    <!-- Import Web Core 2.x via CDN -->
+    <script src="https://cdn.dyte.in/core/dyte2.js"></script>
 
     <!-- Video Background Transformer -->
-    <script src="https://cdn.jsdelivr.net/npm/@dytesdk/video-background-transformer/dist/index.iife.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@dytesdk/video-background-transformer@latest/dist/index.iife.js"></script>
 
     <style>
       * {
@@ -298,8 +298,16 @@
 
         document.getElementById('my-meeting').meeting = meeting;
 
+        /**
+         * To customise DyteVideoBackgroundTransformer configs, please refer to https://www.npmjs.com/package/@dytesdk/video-background-transformer?activeTab=readme.
+        */
         const dyteVideoBackgroundTransformer =
-          await DyteVideoBackgroundTransformer.init(meeting.self.rawVideoTrack);
+          await DyteVideoBackgroundTransformer.init({
+            meeting,
+            segmentationConfig: {
+              pipeline: 'canvas2dCpu', // 'webgl2' | 'canvas2dCpu'
+            }
+          });
 
         let activeMiddleware;
 

--- a/samples/default-meeting-ui/index.html
+++ b/samples/default-meeting-ui/index.html
@@ -5,22 +5,19 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Default Meeting UI | Dyte UI Kit</title>
+    <!--
+      For the UI Kit and Web Core script tags,
+      make sure to use the latest versions in the URL when you're using this
+    -->
 
-    <head>
-      <!--
-        For the UI Kit and Web Core script tags,
-        make sure to use the latest versions in the URL when you're using this
-      -->
+    <!-- Import helper to load UI Kit components -->
+    <script type="module">
+      import { defineCustomElements } from 'https://cdn.jsdelivr.net/npm/@dytesdk/ui-kit@latest/loader/index.es2017.js';
+      defineCustomElements();
+    </script>
 
-      <!-- Import helper to load UI Kit components -->
-      <script type="module">
-        import { defineCustomElements } from 'https://cdn.jsdelivr.net/npm/@dytesdk/ui-kit@latest/loader/index.es2017.js';
-        defineCustomElements();
-      </script>
-
-      <!-- Import Web Core via CDN too -->
-      <script src="https://cdn.dyte.in/core/dyte.js"></script>
-    </head>
+    <!-- Import Web Core 2.x via CDN -->
+    <script src="https://cdn.dyte.in/core/dyte2.js"></script>
   </head>
   <body>
     <dyte-meeting id="my-meeting" show-setup-screen="true" />

--- a/samples/with-background-transformer/README.md
+++ b/samples/with-background-transformer/README.md
@@ -10,7 +10,7 @@ package.
 You can set:
 
 1. A background blur
-2. A backgriund image
+2. A background image
 
 <!-- With blur:
 

--- a/samples/with-background-transformer/index.html
+++ b/samples/with-background-transformer/index.html
@@ -17,11 +17,11 @@
       defineCustomElements();
     </script>
 
-    <!-- Import Web Core via CDN too -->
-    <script src="https://cdn.dyte.in/core/dyte.js"></script>
+    <!-- Import Web Core 2.x via CDN -->
+    <script src="https://cdn.dyte.in/core/dyte2.js"></script>
 
     <!-- Video Background Transformer -->
-    <script src="https://cdn.jsdelivr.net/npm/@dytesdk/video-background-transformer/dist/index.iife.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@dytesdk/video-background-transformer@latest/dist/index.iife.js"></script>
   </head>
   <body>
     <dyte-meeting id="my-meeting" show-setup-screen="true" />
@@ -44,22 +44,30 @@
       }).then(async (meeting) => {
         document.getElementById('my-meeting').meeting = meeting;
 
+        /**
+         * To customise DyteVideoBackgroundTransformer configs, please refer to https://www.npmjs.com/package/@dytesdk/video-background-transformer?activeTab=readme.
+        */
         const videoBackgroundTransformer =
-          await DyteVideoBackgroundTransformer.init();
+          await DyteVideoBackgroundTransformer.init({
+            meeting,
+            segmentationConfig: {
+              pipeline: 'canvas2dCpu', // 'webgl2' | 'canvas2dCpu'
+            }
+          });
 
         // The video-background-transformer provides two functionalities
         // 1. Add background blur
         // 2. Add a background image
 
         // 1. To add background blur, with strength of 10
-        // meeting.self.addVideoMiddleware(
-        //   await videoBackgroundTransformer.createBackgroundBlurVideoMiddleware(
-        //     10
-        //   )
-        // );
+        //  await meeting.self.addVideoMiddleware(
+        //     await videoBackgroundTransformer.createBackgroundBlurVideoMiddleware(
+        //       10
+        //     )
+        //   );
 
         // 2. To add a background image
-        meeting.self.addVideoMiddleware(
+        await meeting.self.addVideoMiddleware(
           await videoBackgroundTransformer.createStaticBackgroundVideoMiddleware(
             'https://assets.dyte.io/backgrounds/bg-dyte-office.jpg'
           )


### PR DESCRIPTION
Exposed segmentationConfig in the samples.

Currently  canvas2dCpu pipeline supports varying blur but  webgl2 doesn't. Support for varying length of blur using webgl2 pipeline will be added later.